### PR TITLE
Hardcode table name in create statement

### DIFF
--- a/defender.py
+++ b/defender.py
@@ -142,7 +142,7 @@ def create_log_table(database, tablename):
     c = conn.cursor()
     # Create SQL Table.
     create_table_sql = f'''
-    CREATE TABLE IF NOT EXISTS {tablename} (
+    CREATE TABLE IF NOT EXISTS cloudtrail (
         event_id TEXT PRIMARY KEY,
         event_version TEXT,
         event_type TEXT,

--- a/defender.py
+++ b/defender.py
@@ -137,11 +137,11 @@ def get_policy_details(profile, repository):
     pprint(ecr_policy)
 
 
-def create_log_table(database, tablename):
+def create_log_table(database):
     conn = sqlite3.connect(database)
     c = conn.cursor()
     # Create SQL Table.
-    create_table_sql = f'''
+    create_table_sql = '''
     CREATE TABLE IF NOT EXISTS cloudtrail (
         event_id TEXT PRIMARY KEY,
         event_version TEXT,
@@ -256,7 +256,7 @@ def main():
 
     # Objective 6: Query the logs.
 
-    create_log_table('logs', 'cloudtrail')
+    create_log_table('logs')
 
     sql_files = list_all_files('test')
     for file in sql_files:

--- a/queries.sql
+++ b/queries.sql
@@ -26,6 +26,7 @@ SELECT CASE
   FROM cloudtrail
 ),
 last_event AS (
+-- This window function requires sqlite3 version 3.25 or later.
 SELECT account_id,
        event_time,
        LAG(event_time) OVER (PARTITION BY account_id ORDER BY event_time) AS time_of_last_event


### PR DESCRIPTION
Previous PR used fstring for table name, but hardcoded table names are more secure against sql injection.  This update uses a hardcoded table name instead.
