### PR TITLE
Cleanup

### DIFF
--- a/defender.py
+++ b/defender.py
@@ -19,7 +19,6 @@ import sqlite3
 from sqlite3 import Error
 
 
-
 def define_session_clients(account):
     """ Defines the AWS session and relevant clients for a profile.
 
@@ -48,7 +47,7 @@ def list_bucket_names(s3_client):
 
 
 def define_bucket(session, bucket):
-    """ Returns an s3 bucket object for a session and bucket. """ 
+    """ Returns an s3 bucket object for a session and bucket. """
     s3_resource = session.resource('s3')
     return s3_resource.Bucket(bucket)
 
@@ -85,7 +84,7 @@ def s3_sync(bucket, target_directory):
 
 def list_all_files(downloaded_directory):
     """ Returns a list of the gzip files in a directory.
-    
+
     Args:
         downloaded_directory (str): The name of the directory to search for gzip files.
 

--- a/defender.py
+++ b/defender.py
@@ -76,11 +76,11 @@ def s3_sync(bucket, target_directory):
         os.makedirs(nested_directory)
     files = set(os.listdir(nested_directory))
     print(nested_directory)
+    # Download files that are present in the AWS bucket but not the local directory.
     for obj in bucket.objects.all():
-        obj_filename = obj.key
-        if obj_filename not in files:
-            bucket.download_file(obj_filename, os.path.join(
-                target_directory, obj_filename))
+        if obj.key not in files:
+            bucket.download_file(obj.key, os.path.join(
+                target_directory, obj.key))
 
 
 def list_all_files(downloaded_directory):
@@ -114,10 +114,9 @@ def write_tsv_rows(open_mode, tsv_path, gz_path):
     with open(tsv_path, open_mode) as output_file, gzip.open(gz_path, 'rt') as json_file:
         json_dict = json.load(json_file)
         for record in json_dict['Records']:
-            cleaned_dict = record
-            final_dict = {k: cleaned_dict[k] for k in (
+            final_dict = {k: record[k] for k in (
                 'eventTime', 'sourceIPAddress', 'eventName')}
-            identity_dict = {k: cleaned_dict['userIdentity'].get(
+            identity_dict = {k: record['userIdentity'].get(
                 k, None) for k in ('arn', 'accountId', 'type')}
             final_dict.update(identity_dict)
             tsv = csv.DictWriter(


### PR DESCRIPTION
Removes unneeded imports, comments, and variable assignments.

Makes the following changes:
- [x] Remove unused Pandas import.
- [x] Remove unneeded comments.
- [ ] Lines 26 - 40: `define_session_clients()` uses the keyword `account` when referring to the user's profile.
- [x] Line 93: Remove this line and use `obj.key` through the end of the function definition.
- [x] Line 134: Remove this line and continue using `record` through the end of the function definition.
- [ ] Line 181: Remove this line and continue using `record` through the end of the function definition.
- [ ] Lines 190 & 199: These are defined using define_session_clients.  Change the arguments to accept the iam/ecr client and delete line 190 & line 199.